### PR TITLE
Remove the possibility for transformer inputs/outputs to be null

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -160,6 +160,7 @@ async function generateTranslationStrings(
       })
       value = result.value
     } catch (error) {
+      // FIXME: Get rid of this
       throw error instanceof MissingValueError
         ? new Error(
             `[${brand}] Transformer ${transformerName} requires a translation string value to be provided.\n` +
@@ -168,12 +169,13 @@ async function generateTranslationStrings(
         : error
     }
 
-    if (!value)
+    if (!value) {
+      // FIXME: Get rid of this
       throw new Error(
         `[${brand}] Transformer ${transformerName} didn't return any value.\n` +
           `Translation key being processed: ${key}`
       )
-
+    }
     result[key] = value
 
     if (logger.countMessages(MessageType.Warn)) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -158,13 +158,14 @@ async function generateTranslationStrings(
       throw error
     }
 
-    if (!value) {
-      // FIXME: Get rid of this
+    if (value === "") {
+      debugger
       throw new Error(
-        `[${brand}] Transformer ${transformerName} didn't return any value.\n` +
+        `[${brand}] ${transformerName} returned an empty string!\n` +
           `Translation key being processed: ${key}`
       )
     }
+
     result[key] = value
 
     if (logger.countMessages(MessageType.Warn)) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -19,7 +19,7 @@ import { packDescription } from "./main.js"
 
 /** The output of a {@link Transformer} */
 export type TransformerResult = {
-  value: string | null | undefined
+  value: string
 }
 /** The data provided to {@link Transformer} callback functions */
 export type TransformerCallbackData = {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -94,13 +94,6 @@ export interface OutFileMetadata {
   totalFiles: number
 }
 
-export class MissingValueError extends Error {
-  constructor() {
-    super()
-    this.name = "MissingValueError"
-  }
-}
-
 export abstract class Transformer {
   callback
 
@@ -160,13 +153,9 @@ async function generateTranslationStrings(
       })
       value = result.value
     } catch (error) {
-      // FIXME: Get rid of this
-      throw error instanceof MissingValueError
-        ? new Error(
-            `[${brand}] Transformer ${transformerName} requires a translation string value to be provided.\n` +
-              `Translation key being processed: ${key}`
-          )
-        : error
+      // This is were exceptions from transformer callbacks end up.
+      // We could do some fancier error handling her ein the future.
+      throw error
     }
 
     if (!value) {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -2,7 +2,7 @@ import path from "node:path"
 import { readFile, writeFile } from "node:fs/promises"
 import AdmZip from "adm-zip"
 import {
-  getTranslationString,
+  getTranslationStringOrThrow,
   getVanillaLanguageFile,
   LanguageFileData,
   MinecraftLanguage,
@@ -26,7 +26,7 @@ export type TransformerCallbackData = {
   key: string
   language: MinecraftLanguage
   version: MinecraftVersion
-  oldValue: string | null | undefined
+  oldValue: string
   logger: TransformerLogger
   languageFileData: Record<string, string>
 }
@@ -142,7 +142,7 @@ async function generateTranslationStrings(
 
     const oldValue =
       originalLanguageFile[key] ||
-      (await getTranslationString(key, {
+      (await getTranslationStringOrThrow(key, {
         language: targetLanguage,
         version: targetVersion,
       }))

--- a/src/minecraftHelpers.ts
+++ b/src/minecraftHelpers.ts
@@ -463,6 +463,12 @@ async function getVersionManifest(): Promise<VersionManifest> {
   return result
 }
 
+export interface GetTranslationStringOptions {
+  language: MinecraftLanguage
+  version: MinecraftVersion
+  fallbackLanguage?: MinecraftLanguage | null
+}
+
 export async function getTranslationString(
   key: string,
   options: {
@@ -485,6 +491,23 @@ export async function getTranslationString(
   )
 
   return fallbackLangFile[key] || null
+}
+
+export async function getTranslationStringOrThrow(
+  key: string,
+  options: GetTranslationStringOptions
+) {
+  const matchedTranslationString = await getTranslationString(key, options)
+
+  if (!matchedTranslationString) {
+    throw new Error(
+      `Translation string ${key} doesn't exist! ` +
+        `Target language is ${options.language}. ` +
+        `Target version is ${options.version}.`
+    )
+  }
+
+  return matchedTranslationString
 }
 
 export function packFormat(version: MinecraftVersion) {

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -118,7 +118,7 @@ export class ContextualReplaceTransformer extends Transformer {
 export class TitleCaseTransformer extends Transformer {
   constructor() {
     super(({ oldValue }) => ({
-      value: toTitleCase(oldValue || "") || null,
+      value: toTitleCase(oldValue),
     }))
   }
 }
@@ -129,8 +129,6 @@ export class CapitaliseSegmentTransformer extends Transformer {
 
   constructor(searchValue: FlexibleSearchValue) {
     super(async ({ oldValue, language, version, languageFileData }) => {
-      if (!oldValue) return { value: null }
-
       searchValue = new RegExp(
         await resolveContextSensitiveValue(
           searchValue,
@@ -155,8 +153,6 @@ export class CapitaliseSectionTransformer extends Transformer {
 
   constructor(start: SearchValue | null, end: SearchValue | null) {
     super(({ oldValue, key, logger }) => {
-      if (!oldValue) return { value: null }
-
       const [start, end] = this.range
 
       const simpleStart = typeof start === "string"

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -1,5 +1,4 @@
 import {
-  MissingValueError,
   Transformer,
   TransformerCallback as Callback,
   TransformerCallbackData as CallbackData,
@@ -94,8 +93,6 @@ export class ContextualReplaceTransformer extends Transformer {
     replace: string
   ) {
     super(({ oldValue }) => {
-      if (!oldValue) throw new MissingValueError()
-
       const fullRegex = new RegExp(
         `(?<before>${search.before?.source})(?<target>${search.target.source})(?<after>${search.after?.source})`
       )
@@ -216,7 +213,6 @@ export class CapitaliseFromTranslationStringsTransformer
   options
 
   callback: Callback = async ({ oldValue, language, version }) => {
-    if (!oldValue) throw new MissingValueError()
     const languageFile = await getVanillaLanguageFile(language, version)
 
     const matchingTranslationStrings = Object.entries(languageFile)


### PR DESCRIPTION
I've been meaning to make this change for a while, and it surprisingly went quite smoothly.

For the details, I've pasted a few of the commit comments here:

> **Transformers can no longer be provided with null**
> `TransformerCallbackData#oldValue` will now always be a string. (Previously, transformers would've had to accept `null` or `undefined`.)
> This means that translation keys provided in fixes must exist. In other words, you can no longer create a new translation string with a transformer - only edit ones that exist in vanilla. A mechanic for creating new translation strings will be added in the future. There are no fixes in the pack that will be affected by this change.

> **Remove MissingValueError**
> The `MissingValueError` error is now redundant, since transformers no
longer have to worry about potentially being given a nullish `oldValue`.

> **Update all the transformers**
> This commit removes all the guards that transformers were making against
being given a nullish value. These are all no longer necessary.
> This also means that transformers won't unexpectedly return `null`,
an empty string, or anything like that.

> **Transformers can no longer return a nullish value**
> This is the final step in "fixing" the poor design/architecture decision
which was to allow nulls to be passed through transformers.
> A proper way to create new translation strings will be added in the
future, but for now there are plenty of other bugs to fix!

This is the "important upgrade to the build system" that I mentioned in the [v2.16 release notes](https://github.com/MMK21Hub/Capitalisation-Fixes/releases/tag/v2.16).